### PR TITLE
[feature] Run new-site.sh from its checked out copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,9 +134,20 @@ checkout: \
   $(WP4_CONTENT_DIR)/themes/wp-theme-2018 \
   $(WP4_CONTENT_DIR)/themes/wp-theme-light \
   $(WP_CLI_DIR) \
-  wp-ops
+  wp-ops \
+  volumes/usrlocalbin
 
 git_clone = mkdir -p $(dir $@) || true; cd $(dir $@); test -d $(notdir $@) || git clone $(_GITHUB_BASE)$(strip $(1)) $(notdir $@); touch $(notdir $@)
+
+volumes/usrlocalbin: .docker-all-images-built.stamp
+	mkdir $@
+	docker run --rm  --name volumes-usrlocalbin-extractor \
+	  --entrypoint /bin/bash \
+	  $(DOCKER_MGMT_IMAGE_NAME) \
+	  -c "tar -C/usr/local/bin --exclude=new-wp-site -clf - ." \
+	  | tar -Cvolumes/usrlocalbin -xpvf -
+	ln -s /wp-ops/docker/mgmt/new-wp-site.sh volumes/usrlocalbin/new-wp-site
+	touch $@
 
 $(WP_CONTENT_DIR) $(WP4_CONTENT_DIR): .docker-all-images-built.stamp $(JAHIA2WP_DIR)
 	-rm -f `find $(WP_CONTENT_DIR)/plugins \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,5 +74,7 @@ services:
       - ./volumes/wp:/wp
       - ./volumes/wp/wp-cli/vendor/epfl-idevelop:/var/www/.wp-cli/packages/vendor/epfl-idevelop
       - .env:/srv/.env
+      - ./volumes/usrlocalbin:/usr/local/bin
+      - ./wp-ops:/wp-ops
     ports:
       - "${WP_PORT_SSHD}:22"


### PR DESCRIPTION
- Need two new volumes: /wp-ops contains the wp-ops checked out tree;
  /usr/local/bin is doctored the same way /wp is (using a mix of
  symlinks and binaries extracted from the mgmt image)

- Add appropriate Makefile pipework