### PR TITLE
[feature] Script to copy a hierarchy of WordPress sites from production

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,27 @@ In this repository you will find:
 cd /srv/${WP_ENV}/
 mkdir -p wp-httpd/htdocs
 cd wp-httpd/htdocs</pre>
-1. Create one or more sites under `/srv/${WP_ENV}/wp-httpd/htdocs` using
+
+## Populate the Serving Tree
+
+
+### Copy From Production
+
+This is the easiest way. Assuming you have production access, run <pre>./devscripts/copy-enac-from-prod.sh</pre> to copy a subset of the production serving tree of `www.epfl.ch` into your wp-dev checkout.
+
+### Empty Site
+
+This is more difficult, as the sites created in this way are initially “bare” (they lack symlinks to the plugins, must-use plugins and themes; and they are devoid of configuration and data).
+
+1. Enter the management container (see above), then create one or more sites under `/srv/${WP_ENV}/wp-httpd/htdocs` using
 either the `wp` command-line tool (for a “vanilla” WordPress site) or the [`new-wp-site.sh`](https://github.com/epfl-idevelop/wp-ops/blob/master/docker/mgmt/new-wp-site.sh) command (such a site comes with a number of EPFL-specific presets, main theme disabled etc.)
-3. Browse the site (it's probably not going to work very well at this stage, what with it having no plugins and themes)
-4. Tack `/wp-admin` to the end of the URL to get at the login screen
-5. Log in with the `administrator` account (scroll back in your Terminal looking for `Admin password:` to get at the password)
+1. Browse the site (it's probably not going to work very well at this stage, what with it having no plugins and themes)
+
+## Access the Admin Area
+
+1. Tack `/wp-admin` to the end of the URL to get at the login screen
+1. Log in with the `administrator` account (scroll back in your Terminal looking for `Admin password:` to get at the password)
+1. Because of production-specific reverse-proxy shenanigans, you will be redirected to port 8443 at some point. Just edit the URL to get rid of the `:8443` part.
 
 ### wp-gutenberg-epfl activation
 

--- a/devscripts/copy-enac-from-prod.sh
+++ b/devscripts/copy-enac-from-prod.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+WP_VERSION=5.2
+
 set -e -x
 scriptdir="$(dirname "$0")"
 
@@ -26,11 +28,11 @@ set -e -x
 mkdir -p /srv/test/wp-httpd/htdocs/$site || true
 cd /srv/test/wp-httpd/htdocs/$site
 /usr/local/bin/new-wp-site
+rm wp
+ln -s "/wp/$WP_VERSION" wp
 CREATE_SITE_SCRIPT
 
 cat <<'POPULATE_SITE_SCRIPT'
-rm wp
-ln -s /wp/5.2 wp
 for symlinkdir in wp-content/plugins wp-content/mu-plugins wp-content/themes; do
     mkdir -p "$symlinkdir" || true
     rm -f "$symlinkdir"/*

--- a/devscripts/copy-enac-from-prod.sh
+++ b/devscripts/copy-enac-from-prod.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+set -e -x
+scriptdir="$(dirname "$0")"
+
+wp_export_prod() {
+    ssh -X www-data@ssh-wwp.epfl.ch -p 32222 "cd /srv/www/www.epfl.ch/htdocs/$1; wp db export -"
+}
+
+docker_mgmt_cmd () {
+    if [ -z "$_mgmt_container" ]; then
+        _mgmt_container="$(. "$scriptdir"/../.env; docker ps -q --filter "label=ch.epfl.wordpress.mgmt.env=${WP_ENV}")"
+    fi
+    docker exec -i --user www-data "$_mgmt_container" bash -c "$*"
+}
+
+wp_import_docker() {
+    local site="$1"
+    docker_mgmt_cmd "set -e -x; cd /srv/test/wp-httpd/htdocs/$site; pwd; wp db import -"
+}
+
+wp_prepare () {
+    local site="$1"
+    docker_mgmt_cmd "$(cat <<CREATE_SITE_SCRIPT
+set -e -x
+mkdir -p /srv/test/wp-httpd/htdocs/$site || true
+cd /srv/test/wp-httpd/htdocs/$site
+/usr/local/bin/new-wp-site
+CREATE_SITE_SCRIPT
+
+cat <<'POPULATE_SITE_SCRIPT'
+rm wp
+ln -s /wp/5.2 wp
+for symlinkdir in wp-content/plugins wp-content/mu-plugins wp-content/themes; do
+    mkdir -p "$symlinkdir" || true
+    rm -f "$symlinkdir"/*
+    (cd "$symlinkdir"; pwd; ln -s ../../wp/"$symlinkdir"/* .)
+done
+
+POPULATE_SITE_SCRIPT
+)"
+}
+
+wp_search_replace () {
+    local site="$1"
+    docker_mgmt_cmd "set -e -x; cd /srv/test/wp-httpd/htdocs/$site; wp search-replace https://www.epfl.ch http://wp-httpd"
+}
+
+# TODO: make this flexible (split $1, reverse)
+for site in "" schools schools/enac schools/enac/education3 ; do
+    wp_prepare "$site"
+    wp_export_prod "$site" | wp_import_docker "$site"
+    wp_search_replace "$site"
+done

--- a/devscripts/copy-enac-from-prod.sh
+++ b/devscripts/copy-enac-from-prod.sh
@@ -16,7 +16,7 @@ docker_mgmt_cmd () {
 
 wp_import_docker() {
     local site="$1"
-    docker_mgmt_cmd "set -e -x; cd /srv/test/wp-httpd/htdocs/$site; pwd; wp db import -"
+    docker_mgmt_cmd "set -e -x; cd /srv/test/wp-httpd/htdocs/$site; wp db import -"
 }
 
 wp_prepare () {
@@ -34,7 +34,7 @@ ln -s /wp/5.2 wp
 for symlinkdir in wp-content/plugins wp-content/mu-plugins wp-content/themes; do
     mkdir -p "$symlinkdir" || true
     rm -f "$symlinkdir"/*
-    (cd "$symlinkdir"; pwd; ln -s ../../wp/"$symlinkdir"/* .)
+    (cd "$symlinkdir"; ln -s ../../wp/"$symlinkdir"/* .)
 done
 
 POPULATE_SITE_SCRIPT


### PR DESCRIPTION
- Uses `wp db dump` / `wp db restore` + `wp search-replace`, as per  https://confluence.epfl.ch:8443/pages/viewpage.action?pageId=75662209
- Symlinks sites in a crude fashion (enough for EPFL plug-ins and themes to load)
- Images are *not* synced (5Gb+ to copy? No thanks) — I suppose we could be smarter in the `wp search-replace` to hotlink them out of the production sites