### PR TITLE
Use new repo of epfl-404 plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ checkout: \
   $(WP_CONTENT_DIR)/themes/wp-theme-2018 \
   $(WP_CONTENT_DIR)/themes/wp-theme-light \
   $(WP_CONTENT_DIR)/plugins/wp-gutenberg-epfl \
-	$(WP_CONTENT_DIR)/plugins/epfl-404 \
+  $(WP_CONTENT_DIR)/plugins/epfl-404 \
   $(WP4_CONTENT_DIR)/plugins/accred \
   $(WP4_CONTENT_DIR)/plugins/tequila \
   $(WP4_CONTENT_DIR)/themes/wp-theme-2018 \

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ checkout: \
   wp-ops \
   volumes/usrlocalbin
 
-git_clone = mkdir -p $(dir $@) || true; cd $(dir $@); test -d $(notdir $@) || git clone $(_GITHUB_BASE)$(strip $(1)) $(notdir $@); touch $(notdir $@)
+git_clone = mkdir -p $(dir $@) || true; cd $(dir $@); devscripts/ensure-git-clone.sh $(_GITHUB_BASE)$(strip $(1)) $(notdir $@); touch $(notdir $@)
 
 volumes/usrlocalbin: .docker-all-images-built.stamp
 	mkdir $@ || true

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ checkout: \
   wp-ops \
   volumes/usrlocalbin
 
-git_clone = mkdir -p $(dir $@) || true; cd $(dir $@); devscripts/ensure-git-clone.sh $(_GITHUB_BASE)$(strip $(1)) $(notdir $@); touch $(notdir $@)
+git_clone = mkdir -p $(dir $@) || true; devscripts/ensure-git-clone.sh $(_GITHUB_BASE)$(strip $(1)) $@; touch $@
 
 volumes/usrlocalbin: .docker-all-images-built.stamp
 	mkdir $@ || true

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ checkout: \
   $(WP_CONTENT_DIR)/themes/wp-theme-2018 \
   $(WP_CONTENT_DIR)/themes/wp-theme-light \
   $(WP_CONTENT_DIR)/plugins/wp-gutenberg-epfl \
+	$(WP_CONTENT_DIR)/plugins/epfl-404 \
   $(WP4_CONTENT_DIR)/plugins/accred \
   $(WP4_CONTENT_DIR)/plugins/tequila \
   $(WP4_CONTENT_DIR)/themes/wp-theme-2018 \
@@ -168,7 +169,9 @@ $(WP_CONTENT_DIR) $(WP4_CONTENT_DIR): .docker-all-images-built.stamp $(JAHIA2WP_
 	for linkable in \
 	    $(shell cd $(JAHIA2WP_DIR)/data/wp/wp-content; \
 	                  find themes plugins -mindepth 1 -maxdepth 1 -type d \
-	                  -not -name epfl-menus); \
+                    -not -name epfl-menus \
+                    -not -name epfl-404 \
+                    ); \
 	do \
 	  rm -rf $(WP_CONTENT_DIR)/$$linkable $(WP4_CONTENT_DIR)/$$linkable; \
 	  ln -s ../../../jahia2wp/data/wp/wp-content/$$linkable \
@@ -215,6 +218,9 @@ $(WP_CONTENT_DIR)/themes/wp-theme-light: $(WP_CONTENT_DIR)/themes/wp-theme-2018.
 
 $(WP_CONTENT_DIR)/plugins/epfl-menus: $(WP_CONTENT_DIR)
 	$(call git_clone, epfl-idevelop/wp-plugin-epfl-menus)
+
+$(WP_CONTENT_DIR)/plugins/epfl-404: $(WP_CONTENT_DIR)
+	$(call git_clone, epfl-idevelop/wp-plugin-epfl-404)
 
 $(WP_CLI_DIR):
 	$(call git_clone, epfl-idevelop/wp-cli)

--- a/devscripts/ensure-git-clone.sh
+++ b/devscripts/ensure-git-clone.sh
@@ -1,4 +1,24 @@
 #!/bin/sh
 ## Usage : 
 ## ensure-git-clone.sh <gitURL> <directory>
-test -d "$2" || git clone "$1" "$2"
+
+set -e -x
+
+GIT_URL="$1"
+TARGET_DIR="$2"
+
+do_git_clone() {
+    git clone "$GIT_URL" "$TARGET_DIR"
+}
+
+if test -L "$TARGET_DIR"; then
+    # Was probably a link to a module under jahia2wp, which got re-hosted.
+    rm "$TARGET_DIR"
+fi
+
+if ! test -d "$TARGET_DIR"; then
+    do_git_clone
+elif [ "$(cd "$TARGET_DIR" && git remote get-url origin)" != "$GIT_URL" ] ; then
+    mv "$TARGET" "$TARGET"-orig
+    do_git_clone
+fi

--- a/devscripts/ensure-git-clone.sh
+++ b/devscripts/ensure-git-clone.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+## Usage : 
+## ensure-git-clone.sh <gitURL> <directory>
+test -d "$2" || git clone "$1" "$2"


### PR DESCRIPTION
Pour que le `make`  utilise le nouveau repo du plugin wp-plugin-epfl-404 , il faut faire un 
`touch volumes/wp/5/wp-content`
Cette comande va changer le timestamp et aura pour conséquence la mise à jour et donc l'utilisation du nouveau repo pour le plugin epfl-404

```
git filter-repo --path data/wp/wp-content/plugins/epfl-404 \
 --path-rename 'data/wp/wp-content/plugins/epfl-404/epfl-404.php:epfl-404.php' \
 --path-rename 'data/wp/wp-content/plugins/epfl-404/inc:inc' \
 --force
```