### PR TITLE
Readd the ip declaration on Darwin systems when using xdebug

### DIFF
--- a/devscripts/myip
+++ b/devscripts/myip
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Print the local IP address to stdout
+#
+# The purpose is to tell things inside the Docker container (e.g.,
+# some PHP or Python code) how to reach other things on the
+# workstation (e.g. a debugger).
+#
+# If we don't currently have an IP address (for instance we are in the
+# bus), and --ensure is passed as the first command-line argument, set
+# up an IP address.
+
+. "$(dirname "$0")"/functions.sh
+
+main () {
+    if [ "$1" == "--ensure" ]; then
+        shift
+        case "$(uname -s)" in
+            Darwin) myip_mac "$@" >/dev/null || setup_ip_mac "$@";;
+            Linux) myip_linux "$@" >/dev/null || setup_ip_linux "$@";;
+            *) die "Sorry, unsupported OS: $(uname -s)" ;;
+        esac
+    else
+        case "$(uname -s)" in
+            Darwin) myip_mac "$@";;
+            Linux) myip_linux "$@";;
+            *) die "Sorry, unsupported OS: $(uname -s)" ;;
+        esac
+    fi
+}
+
+myip_linux () {
+    die "myip_linux is UNIMPLEMENTED"
+}
+
+myip_mac () {
+    ifconfig | (
+        while read inet ip rest; do
+            [ "$inet" == "inet" ] || continue
+            case "$ip" in
+                127.*|172.1*|172.2*) continue ;;
+            esac
+            echo $ip
+            return 0
+        done
+        return 1
+    )
+}
+
+setup_ip_linux () {
+    die "myip_linux is UNIMPLEMENTED"
+}
+
+setup_ip_mac () {
+    sudo ifconfig bridge0 192.168.59.97
+}
+
+##########################################################################
+main "$@"

--- a/devscripts/php-xdebug
+++ b/devscripts/php-xdebug
@@ -48,7 +48,8 @@ case "$1" in
         xdebug.remote_enable=on
         xdebug.remote_autostart=on
         xdebug.remote_connect_back=on
-EOF;;
+EOF
+            ;;
             # Darwin is not, so use the current ip strategy
             *)
                 myip --ensure
@@ -57,7 +58,9 @@ EOF;;
         xdebug.remote_enable=on
         xdebug.remote_autostart=on
         xdebug.remote_host=$(myip)
-EOF;;
+EOF
+            ;;
+        esac
         ;;
     stop)
         $dockerexec sh -c \

--- a/devscripts/php-xdebug
+++ b/devscripts/php-xdebug
@@ -20,6 +20,9 @@ https://www.jetbrains.com/help/idea/configuring-xdebug.html
 USAGE
 }
 
+myip () {
+    $(dirname "$0")/myip "$@"
+}
 
 dockerexec="docker exec -i wp-httpd"
 
@@ -37,12 +40,24 @@ set -e
 case "$1" in
     start)
         ensure_php_xdebug_installed
-        $dockerexec sh -c \
-            'cat > /etc/php/$PHP_VERSION/apache2/conf.d/99-debug.ini' <<EOF
-xdebug.remote_enable=on
-xdebug.remote_autostart=on
-xdebug.remote_connect_back=on
-EOF
+        case "$(uname -s)" in
+            # Linux is ok with the xdebug remote_connect_back strategy
+            Linux)
+                $dockerexec sh -c \
+                    'cat > /etc/php/$PHP_VERSION/apache2/conf.d/99-debug.ini' <<EOF
+        xdebug.remote_enable=on
+        xdebug.remote_autostart=on
+        xdebug.remote_connect_back=on
+EOF;;
+            # Darwin is not, so use the current ip strategy
+            *)
+                myip --ensure
+                $dockerexec sh -c \
+                    'cat > /etc/php/$PHP_VERSION/apache2/conf.d/99-debug.ini' <<EOF
+        xdebug.remote_enable=on
+        xdebug.remote_autostart=on
+        xdebug.remote_host=$(myip)
+EOF;;
         ;;
     stop)
         $dockerexec sh -c \


### PR DESCRIPTION
Darwin systems do not like the xdebug.remote_connect_back strategy, so a check is made and we use it only for Linux systems