### PR TITLE
[feature] `make checkout` now daisy-chains into wp-ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ $(WP_CLI_DIR):
 
 wp-ops:
 	$(call git_clone, epfl-idevelop/wp-ops)
+	$(MAKE) -C wp-ops checkout
 
 ############ Additional symlinks for obsolete WordPress 4 codebase ###########
 $(WP4_CONTENT_DIR)/plugins/%: $(WP4_CONTENT_DIR)


### PR DESCRIPTION
After [wp-ops' #157](https://github.com/epfl-idevelop/wp-ops/pull/157), wp-ops has
sub-gits and needs `make checkout` to become fully operational.
Arrange for wp-dev to pass on the `make checkout` goodness.